### PR TITLE
Enhance Validation Logic and Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ plugins {
 
 ### Step 2: Configure the plugin in the root `build.gradle[.kts]` file
 ```kotlin
-configure<JacocoAggregateCoveragePluginExtension> {
+jacocoAggregateCoverage {
     jacocoTestReportTask.set("YOUR_JACOCO_TEST_REPORT_TASK")
     // Other optional configurations
 }
@@ -41,7 +41,7 @@ The unified report will be generated at **`build/reports/jacocoAggregated/index.
 # Configuration
 Configure the plugin in your root-level `build.gradle[.kts]` file:
 ```kotlin
-configure<JacocoAggregateCoveragePluginExtension> {
+jacocoAggregateCoverage {
     jacocoTestReportTask.set("jacocoTestDebugUnitTestReport")
     // Add the report directory only if you have a custom directory set
     configuredCustomReportsDirectory.set("customJacocoReportDir")

--- a/jacocoaggregatecoverageplugin/src/main/kotlin/com/azizutku/jacocoaggregatecoverageplugin/CopyJacocoReportsTask.kt
+++ b/jacocoaggregatecoverageplugin/src/main/kotlin/com/azizutku/jacocoaggregatecoverageplugin/CopyJacocoReportsTask.kt
@@ -68,7 +68,6 @@ internal abstract class CopyJacocoReportsTask : DefaultTask() {
         }
         copyRequiredResources(outputDirectoryResources.get().asFile)
 
-        var foundAny = false
         project.subprojects.forEach { subproject ->
             val jacocoReportDir = subproject.layout.buildDirectory
                 .dir(reportDirectory)
@@ -80,17 +79,7 @@ internal abstract class CopyJacocoReportsTask : DefaultTask() {
                     from(jacocoReportDir)
                     into(aggregatedReportDir.get().dir(subproject.path))
                 }
-                foundAny = true
             }
-        }
-
-        if (foundAny.not()) {
-            logger.error(
-                "There is no generated test report, you should " +
-                    "run `${pluginExtension.jacocoTestReportTask.get()}` task first, " +
-                    "then call `aggregateJacocoReports`. Or you can run " +
-                    "`generateAndAggregateJacocoReports` task directly."
-            )
         }
     }
 

--- a/jacocoaggregatecoverageplugin/src/main/kotlin/com/azizutku/jacocoaggregatecoverageplugin/JacocoAggregateCoveragePlugin.kt
+++ b/jacocoaggregatecoverageplugin/src/main/kotlin/com/azizutku/jacocoaggregatecoverageplugin/JacocoAggregateCoveragePlugin.kt
@@ -70,6 +70,17 @@ internal class JacocoAggregateCoveragePlugin : Plugin<Project> {
                 project.layout.buildDirectory.dir(PLUGIN_OUTPUT_PATH)
             )
             val jacocoTestReportTasks = getJacocoTestReportTasks(project, pluginExtension)
+            if (jacocoTestReportTasks.isEmpty()) {
+                val jacocoTestReportTask = pluginExtension.jacocoTestReportTask.get()
+                project.logger.error(
+                    """
+                        There are no tasks named '$jacocoTestReportTask' in your project. Please 
+                        ensure that you set the `jacocoTestReportTask` property in the plugin 
+                        extension to the name of the task you use to generate JaCoCo test reports.
+                    """.trimIndent()
+                )
+                return@configure
+            }
             copyReportsTaskProvider.get().mustRunAfter(jacocoTestReportTasks)
             dependsOn(copyReportsTaskProvider)
             dependsOn(jacocoTestReportTasks)


### PR DESCRIPTION
This PR brings two improvements to the plugin:

1.  Added a new validation check that ensures the `jacocoTestReportTask` is configured correctly. 
2. Removed `foundAny` check, which previously verified the presence of generated JaCoCo reports, has been removed. This is based on that JaCoCo does not generate reports when there are no unit tests present.

Additionally, the `README.md` has been updated.